### PR TITLE
Remove older WAL log if it already exists

### DIFF
--- a/src/smdba/smdba-pgarchive
+++ b/src/smdba/smdba-pgarchive
@@ -42,12 +42,14 @@ if [ -f "$DESTINATION" ]; then
     # file already exist in the backup
     # remove it and exit with error.
     echo "File already exists: $DESTINATION" >&2
-    rm -f $DESTINATION
     exit 1
 fi
 
 if ! cp --preserve=all $SOURCE $DESTINATION; then
     echo "Copy command failed" >&2
+    if [ -e "$DESTINATION" ]; then
+	rm -f $DESTINATION
+    fi
     exit 1
 fi
 

--- a/src/smdba/smdba-pgarchive
+++ b/src/smdba/smdba-pgarchive
@@ -40,8 +40,9 @@ fi
 
 if [ -f "$DESTINATION" ]; then
     # file already exist in the backup
-    # exit with error
+    # remove it and exit with error.
     echo "File already exists: $DESTINATION" >&2
+    rm -f $DESTINATION
     exit 1
 fi
 


### PR DESCRIPTION
If "no space left on device" or for some reasons backup WAL file is already copied, this script exits with an error, leaving file at destination point. Seems that failed exit PostgreSQL is understood atomically, therefore the process is scheduled to be repeated again. While if device is no longer writable, this will loop until device is writable again. However, if the file is already in the destination, it should reset the copy process and  successfully continue.

@dmacvicar @mcalmer Please take a look.