### PR TITLE
Fix postgres space-overview command

### DIFF
--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -465,6 +465,7 @@ class PgSQLGate(BaseGate):
         class Info:
             fs_dev = None
             fs_type = None
+            size = None
             used = None
             available = None
             used_prc = None
@@ -478,7 +479,8 @@ class PgSQLGate(BaseGate):
             line = filter(None, line.split(" "))
             info.fs_dev = line[0]
             info.fs_type = line[1]
-            info.used = int(line[2]) * 1024 # Bytes
+            info.size = int(line[2]) * 1024 # Bytes
+            info.used = int(line[3]) * 1024 # Bytes
             info.available = int(line[4]) * 1024 # Bytes
             info.used_prc = line[5]
             info.mountpoint = line[6]
@@ -501,6 +503,7 @@ class PgSQLGate(BaseGate):
             overview.append((d_name, self._bt_to_mb(d_size),
                              self._bt_to_mb(info.available - d_size),
                              '%.3f' % round((float(d_size) / float(info.available) * 100), 3)))
+
 
         print >> sys.stdout, "\n", TablePrint(overview), "\n"
 

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -493,7 +493,7 @@ class PgSQLGate(BaseGate):
                                                                                                 'select pg_database_size(datname), datname from pg_database;'),
                                       None, "-u", "postgres", "/bin/bash")
         self.to_stderr(stderr)
-        overview = [('Tablespace', 'Size (Mb)', 'Avail (Mb)', 'Use %',)]
+        overview = [('Database', 'DB Size (Mb)', 'Avail (Mb)', 'Partition Disk Size (Mb)', 'Use %',)]
         for line in stdout.split("\n")[2:]:
             line = filter(None, line.strip().replace('|', '').split(" "))
             if len(line) != 2:
@@ -501,8 +501,9 @@ class PgSQLGate(BaseGate):
             d_size = int(line[0])
             d_name = line[1]
             overview.append((d_name, self._bt_to_mb(d_size),
-                             self._bt_to_mb(info.available - d_size),
-                             '%.3f' % round((float(d_size) / float(info.available) * 100), 3)))
+                             self._bt_to_mb(info.available),
+                             self._bt_to_mb(info.size),
+                             '%.3f' % round((float(d_size) / float(info.size) * 100), 3)))
 
 
         print >> sys.stdout, "\n", TablePrint(overview), "\n"


### PR DESCRIPTION
This fix how we compute the `smdba space-overview` command.

With this PR the output will show the partition disk size where the database lives. The percentage of the usage is computed then between the database size and the whole partition size.

```
Database    | DB Size (Mb) | Avail (Mb) | Partition Disk Size (Mb) | Use %
------------+--------------+------------+--------------------------+------
postgres    | 7            | 69059      | 100664                   | 0.007
susemanager | 2539         | 69059      | 100664                   | 2.522 
```

This is totally different from the Oracle command since the in Postgres there is no report about the **database allocation limit** and **current tablespace size** so the only relevant report can be between the **current database size** and the **size of the disk**.