### PR TITLE
#bsc1002231

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup (
   name = 'SUSE Manager Database Control',
-  version = '1.5.4',
+  version = '1.5.5',
   package_dir = {'': 'src'},
   package_data={'smdba': ['scenarios/*.scn']},
   packages = [

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -639,6 +639,10 @@ class PgSQLGate(BaseGate):
         """
         Restore the SUSE Manager Database from backup.
         """
+        # Go out from the current position, in case user is calling SMDBA inside the "data" directory
+        location_begin = os.getcwd()
+        os.chdir('/')
+
         # This is the ratio of compressing typical PostgreSQL cluster tablespace
         ratio = 0.134
 
@@ -673,6 +677,10 @@ class PgSQLGate(BaseGate):
         # Replace with new backup
         self._rst_replace_new_backup(backup_dst)
         self.do_db_start()
+
+        # Move back where backup has been invoked
+        os.chdir(location_begin)
+
 
     def do_backup_hot(self, *opts, **args):
         """

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -28,7 +28,7 @@
 from basegate import BaseGate
 from basegate import GateException
 from roller import Roller
-from utils import TablePrint
+from utils import TablePrint, get_path_owner
 
 import sys
 import os
@@ -627,6 +627,11 @@ class PgSQLGate(BaseGate):
         cfg = open(recovery_conf, 'w')
         cfg.write("restore_command = 'cp " + backup_dst + "/%f %p'\n")
         cfg.close()
+
+        # Set recovery.conf correct ownership (SMDBA is running as root at this moment)
+        data_owner = get_path_owner(self.config.get('pcnf_pg_data', PgBackup.DEFAULT_PG_DATA))
+        os.chown(recovery_conf, data_owner.uid, data_owner.gid)
+
         print >> sys.stdout, "finished"
         sys.stdout.flush()
 

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -623,7 +623,8 @@ class PgSQLGate(BaseGate):
         sys.stdout.flush()
 
         print >> sys.stdout, "Write recovery.conf:\t ",
-        cfg = open(os.path.dirname(self.config['pcnf_pg_data']) + "/data/recovery.conf", 'w')
+        recovery_conf = os.path.join(self.config['pcnf_pg_data'], "recovery.conf")
+        cfg = open(recovery_conf, 'w')
         cfg.write("restore_command = 'cp " + backup_dst + "/%f %p'\n")
         cfg.close()
         print >> sys.stdout, "finished"

--- a/src/smdba/smdba
+++ b/src/smdba/smdba
@@ -38,7 +38,7 @@ class Console:
     """
 
     # General
-    VERSION = "1.5.4"
+    VERSION = "1.5.5"
     DEFAULT_CONFIG = "/etc/rhn/rhn.conf"
 
     # Config


### PR DESCRIPTION
Fixes the following issues:

1. Sets correct permissions to `recovery.conf`
2. Prevents crash if `smdba` backup restore has been launched in `data` directory.