### PR TITLE
Use systemd for db start/stop, if available.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup (
   name = 'SUSE Manager Database Control',
-  version = '1.5.5',
+  version = '1.5.6',
   package_dir = {'': 'src'},
   package_data={'smdba': ['scenarios/*.scn']},
   packages = [

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -341,6 +341,7 @@ class PgSQLGate(BaseGate):
         if self._with_systemd:
             result = os.system('systemctl start postgresql.service')
         else:
+            # This is obsolete code, going to be removed after 2.1 EOL
             result = os.system("sudo -u postgres /usr/bin/pg_ctl start -s -w -p /usr/bin/postmaster -D %s -o %s 2>&1>/dev/null"
                                % (self.config['pcnf_pg_data'], self.config.get('sysconfig_POSTGRES_OPTIONS', '""')))
         print >> sys.stdout, result and "failed" or "done"
@@ -367,6 +368,7 @@ class PgSQLGate(BaseGate):
         if self._with_systemd:
             result = os.system('systemctl stop postgresql.service')
         else:
+            # This is obsolete code, going to be removed after 2.1 EOL
             result = os.system("sudo -u postgres /usr/bin/pg_ctl stop -s -D %s -m fast"
                                % self.config.get('pcnf_data_directory', ''))
         print >> sys.stdout, result and "failed" or "done"

--- a/src/smdba/smdba
+++ b/src/smdba/smdba
@@ -44,7 +44,6 @@ class Console:
     # Config
     DB_BACKEND = "db_backend"
 
-
     def __init__(self, configpath=None):
         """
         Constructor.
@@ -56,7 +55,6 @@ class Console:
         else:
             self.get_config_auto()
         self.load_db_backend()
-
 
     def load_db_backend(self):
         """
@@ -75,7 +73,6 @@ class Console:
             else:
                 raise Exception("Unknown database backend and config was not specified.")
 
-
     def get_config_auto(self):
         """
         Manual config.
@@ -85,7 +82,6 @@ class Console:
         if not 'backend' in params.keys():
             raise Exception("When using Auto, you need also load backend.\nBut you should not manually use Auto at first place!")
         self.config = {'db_backend' : params.get('backend', 'unknown')}
-
 
     def get_config(self):
         """
@@ -109,12 +105,10 @@ class Console:
             except:
                 pass
 
-
     @staticmethod
     def usage_header():
         print "SUSE Manager Database Control. Version", Console.VERSION
         print "Copyright (c) 2012 by SUSE Linux Products GmbH\n"
-
 
     def usage(self, command=None):
         """
@@ -147,7 +141,6 @@ class Console:
         print >> sys.stderr, "\nTo know a complete description of each command, use parameter 'help'."
         print >> sys.stderr, "Usage:\n\tsmdba <command> help <ENTER>\n"
 
-
     def translate_command(self, command):
         """
         Translate from "do_something_like_this" as a method name
@@ -155,7 +148,6 @@ class Console:
         """
 
         return command.startswith("do_") and command[3:].replace("_", "-") or ("do_" + command.replace("-", "_"))
-
 
     def execute(self, command):
         """
@@ -177,14 +169,12 @@ class Console:
                 raise Exception(("The parameter \"%s\" is an unknown command.\n\n"  % command[0]) + 
                                 "Hint: Try with no parameters first, perhaps?")
 
-
     def execute_static(self, commands):
         """
         Execute static commands.
         """
         if commands[0] == '--help':
             self.usage()
-
 
     def get_opts(self, opts):
         """
@@ -223,12 +213,12 @@ def main():
     """
     Main app runner.
     """
-    Console.usage_header()
     try:
         console = Console()
         if len(sys.argv[1:]) > 0:
             console.execute(sys.argv[1:])
         else:
+            Console.usage_header()
             console.usage()
     except GateException, err:
         format_error("Backend error", err)
@@ -236,7 +226,6 @@ def main():
     except Exception, err:
         format_error("General error", err)
         sys.exit(1)
-
 
 
 if __name__ == "__main__":

--- a/src/smdba/smdba
+++ b/src/smdba/smdba
@@ -38,7 +38,7 @@ class Console:
     """
 
     # General
-    VERSION = "1.5.5"
+    VERSION = "1.5.6"
     DEFAULT_CONFIG = "/etc/rhn/rhn.conf"
 
     # Config


### PR DESCRIPTION
Before SMDBA was starting/stopping PostgreSQL by its own replicating Dobby's behaviour. This change allows to use `systemd`, if it is around.

Older code is not removed yet for a while in case non-systemd machines are still used.