### PR TITLE
update autotuning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup (
   name = 'SUSE Manager Database Control',
-  version = '1.5.9',
+  version = '1.6.0',
   package_dir = {'': 'src'},
   package_data={'smdba': ['scenarios/*.scn']},
   packages = [

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -896,7 +896,8 @@ class PgSQLGate(BaseGate):
         """
         Common backend healthcheck.
         @help
-        autotuning\tperform initial autotuning of the database
+        autotuning\t\tperform initial autotuning of the database
+	--max_connections=<num>\tdefine maximal number of database connections (default: 400)
         """
         # Check enough space
 

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -963,6 +963,11 @@ class PgSQLGate(BaseGate):
             conf['bytea_output'] = "'escape'"
             changed = True
 
+        # bsc#1022286 - too low value for statistic_target
+        if int(conf.get('default_statistics_target', 100)) <= 10:
+            del conf['default_statistics_target']
+            changed = True
+
         #
         # Setup pg_hba.conf
         # Format is pretty specific :-)

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -910,8 +910,9 @@ class PgSQLGate(BaseGate):
         #
 
         # Built-in tuner
-        conn_lowest = 400
-        max_conn = int(params.get('max_connections', conn_lowest))
+        conn_lowest = 270
+        conn_default = 400
+        max_conn = int(params.get('max_connections', conn_default))
         if max_conn < conn_lowest:
             print >> sys.stdout, 'INFO: max_connections should be at least {0}'.format(conn_lowest)
             max_conn = conn_lowest

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -929,7 +929,7 @@ class PgSQLGate(BaseGate):
             changed = True
 
         # WAL senders at least 5
-        if not conf.get('max_wal_senders') or conf.get('max_wal_senders') < '5':
+        if not conf.get('max_wal_senders') or int(conf.get('max_wal_senders')) < 5:
             conf['max_wal_senders'] = 5
             changed = True
 
@@ -949,7 +949,7 @@ class PgSQLGate(BaseGate):
             changed = True
 
         # max_locks_per_transaction
-        if not conf.get('max_locks_per_transaction') or conf.get('max_locks_per_transaction') < '100':
+        if not conf.get('max_locks_per_transaction') or int(conf.get('max_locks_per_transaction')) < 100:
             conf['max_locks_per_transaction'] = 100
             changed = True
 

--- a/src/smdba/smdba
+++ b/src/smdba/smdba
@@ -39,7 +39,7 @@ class Console:
     """
 
     # General
-    VERSION = "1.5.9"
+    VERSION = "1.6.0"
     DEFAULT_CONFIG = "/etc/rhn/rhn.conf"
 
     # Config


### PR DESCRIPTION
Some changes to autotuning:

- allow 270 connections while the default still stay with 400
- reset default_statistic_target if the value is lower than 10
- fix compare operations
- write help for specifying max_connections
