### PR TITLE
With support of postgresql10 minimum required version will be 10.5; f…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup (
   name = 'SUSE Manager Database Control',
-  version = '1.6.0',
+  version = '1.6.1',
   package_dir = {'': 'src'},
   package_data={'smdba': ['scenarios/*.scn']},
   packages = [

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -193,7 +193,9 @@ class PgSQLGate(BaseGate):
         Check system requirements for this gate.
         """
         msg = None
-        if os.popen('/usr/bin/postmaster --version').read().strip().split(' ')[-1] < '9.1':
+        minversion = [10, 5]
+        pg_version = os.popen('/usr/bin/postmaster --version').read().strip().split(' ')[-1].split('.')
+        if int(pg_version[0]) < minversion[0] or (int(pg_version[0]) == minversion[0] and int(pg_version[1]) < minversion[1]):
             raise GateException("Core component is too old version.")
         elif not os.path.exists("/etc/sysconfig/postgresql"):
             raise GateException("Custom database component? Please strictly use SUSE components only!")

--- a/src/smdba/smdba
+++ b/src/smdba/smdba
@@ -39,7 +39,7 @@ class Console:
     """
 
     # General
-    VERSION = "1.6.0"
+    VERSION = "1.6.1"
     DEFAULT_CONFIG = "/etc/rhn/rhn.conf"
 
     # Config


### PR DESCRIPTION
$SUBJECT pretty much says it all. We need numeric checks now. Lexicographic checks will not detect that "10" is greater than "9"