### PR TITLE
fix parameters of pg_basebackup for version 10: -x no longer exists a…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup (
   name = 'SUSE Manager Database Control',
-  version = '1.6.1',
+  version = '1.6.2',
   package_dir = {'': 'src'},
   package_data={'smdba': ['scenarios/*.scn']},
   packages = [

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -801,7 +801,7 @@ class PgSQLGate(BaseGate):
             b_dir_temp = os.path.join(backup_dir, 'tmp')
             cwd = os.getcwd()
             os.chdir(self.config.get('pcnf_data_directory', '/var/lib/pgsql'))
-            os.system('sudo -u postgres /usr/bin/pg_basebackup -D {0}/ -Ft -c fast -x -v -P -z'.format(b_dir_temp))
+            os.system('sudo -u postgres /usr/bin/pg_basebackup -D {0}/ -Ft -c fast -v -P -z'.format(b_dir_temp))
             os.chdir(cwd)
 
             if os.path.exists("{0}/base.tar.gz".format(b_dir_temp)):

--- a/src/smdba/smdba
+++ b/src/smdba/smdba
@@ -39,7 +39,7 @@ class Console:
     """
 
     # General
-    VERSION = "1.6.1"
+    VERSION = "1.6.2"
     DEFAULT_CONFIG = "/etc/rhn/rhn.conf"
 
     # Config


### PR DESCRIPTION
…nd was not needed in previous versions

With postgresql10, the backup command no longer supports parameter "-x". If I understand the documentation correctly, in previous versions it only was needed in combination with "--xlog-method=fetch" which we are not using, the just remove this parameter. Alternatively we need to use different parameters depending on the postgresql version. In any case current version does not work with postgresql10, but without the offending parameter it works just fine.