### PR TITLE
Remove reference to deprecated command in man page

### DIFF
--- a/doc/smdba-man.xml
+++ b/doc/smdba-man.xml
@@ -128,17 +128,6 @@ below).</simpara>
 </varlistentry>
 <varlistentry>
 <term>
-<emphasis role="strong">db-check</emphasis>
-</term>
-<listitem>
-<simpara>
-    Check full connection to the database. In some vendors it involves check
-    of the whole chain of listeners and backend connectivity.
-</simpara>
-</listitem>
-</varlistentry>
-<varlistentry>
-<term>
 <emphasis role="strong">db-start</emphasis>
 </term>
 <listitem>

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup (
   name = 'SUSE Manager Database Control',
-  version = '1.6.2',
+  version = '1.6.3',
   package_dir = {'': 'src'},
   package_data={'smdba': ['scenarios/*.scn']},
   packages = [

--- a/src/smdba/smdba
+++ b/src/smdba/smdba
@@ -9,10 +9,10 @@
 # deal in the Software without restriction, including without limitation the
 # rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
 # sell copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions: 
+# furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software. 
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -20,8 +20,8 @@
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE. 
-# 
+# IN THE SOFTWARE.
+#
 
 from smdba.basegate import GateException
 import sys
@@ -39,7 +39,7 @@ class Console:
     """
 
     # General
-    VERSION = "1.6.2"
+    VERSION = "1.6.3"
     DEFAULT_CONFIG = "/etc/rhn/rhn.conf"
 
     # Config
@@ -123,7 +123,7 @@ class Console:
                 print >> sys.stdout, "Parameters:"
                 print >> sys.stdout, '\n'.join(["\t" + hl.replace("@nl", "") for hl in help.get('help').split("\n")]) + "\n"
             sys.exit(1)
-        
+
         print >> sys.stderr, "Available commands:"
 
         index_commands = []
@@ -167,7 +167,7 @@ class Console:
                 getattr(self.gate, method)(*args, **params)
                 self.gate.finish()
             else:
-                raise Exception(("The parameter \"%s\" is an unknown command.\n\n"  % command[0]) + 
+                raise Exception(("The parameter \"%s\" is an unknown command.\n\n"  % command[0]) +
                                 "Hint: Try with no parameters first, perhaps?")
 
     def execute_static(self, commands):
@@ -247,7 +247,7 @@ if __name__ == "__main__":
                     inp = None
                 if inp and inp not in ['y', 'n']:
                     print "I was asking you to press \"Y\" key or \"N\" key, but you chose \"Any key\"."
-    
+
             if inp == 'n':
                 print "Good. Don't Ctrl+C anymore!"
                 continue


### PR DESCRIPTION
Issue: https://github.com/SUSE/spacewalk/issues/5977

Per BZ#1109526
See also doc update: https://github.com/SUSE/doc-susemanager/pull/226
