### PR TITLE
Tuning: add cpu_tuple_cost (bsc#1105791)

### DIFF
--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -166,6 +166,7 @@ class PgTune(object):
         self.config['wal_buffers'] = self.to_mb(0x200 * 8)
         self.config['constraint_exclusion'] = 'off'
         self.config['max_connections'] = self.max_connections
+        self.config['cpu_tuple_cost'] = '0.5'
 
         return self
 


### PR DESCRIPTION
https://bugzilla.novell.com/show_bug.cgi?id=1105791

## Background
PostgreSQL queries get executed according to a "query plan", which is generated by an internal PostgreSQL component called the Query Planner. The Planner's job is to figure out the exact sequence of disk operations and other computations in order to elaborate the query itself. It's called a Planner because, given a query, there is always more than one way to implement it correctly, so its job is to employ some heuristics to try to determine the fastest possible plan.

Naturally, the Planner's heuristics can sometimes fail­ — what that happens plans might take a suboptimal amount of time to execute.

PostgreSQL ships with a number of default settings, which among other things "rate" sub-query operations by the expected load they can generate: CPU-wise, RAM-wise and IO-wise. Specifically, those default settings tend to work well in the now-almost-obsolete-assumption of rotating disks, where preferring CPU-bound plans to IO-bound plans is frequently the right thing to do.

Nowadays most SUSE Manager/Uyuni Servers are running on SSDs with abundant RAM, as recommended. That means the default settings sometimes do not work that well - specifically when an an IO-bound plan would be much more appropriate than a CPU-bound one.

## Change
This commit tweaks the default `cpu_tuple_cost` to disincentive the Planner from choosing CPU-bound plans (default is 0.01), and the difference is huge in the particular case of the `allServerKeywordSinceReboot` view for example:

$ time spacewalk-sql --select-mode - <<<"SELECT id, name, selectable FROM allServerKeywordSinceReboot WHERE user_id = 2 AND org_id  = 1 AND keyword = 'reboot_suggested';"
[...]
real    3m32.522s
user    0m0.065s
sys     0m0.029s

$ time spacewalk-sql --select-mode - <<<"SET cpu_tuple_cost = 0.5; SELECT id, name, selectable FROM allServerKeywordSinceReboot WHERE user_id = 2 AND org_id  = 1 AND keyword = 'reboot_suggested';"
[...]
real    0m2.723s
user    0m0.087s
sys     0m0.004s

## Warning
There is a risk that this setting, being set as a default, will make other cases worse - at the moment this has not been observed by the three customers that volunteered to test it.