### PR TITLE
make 'smdba space-overview' postgresql version agnostic; fix version …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup (
   name = 'SUSE Manager Database Control',
-  version = '1.6.3',
+  version = '1.6.4',
   package_dir = {'': 'src'},
   package_data={'smdba': ['scenarios/*.scn']},
   packages = [

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -488,7 +488,9 @@ class PgSQLGate(BaseGate):
                                       None, "-u", "postgres", "/bin/bash")
         self.to_stderr(stderr)
         overview = [('Database', 'DB Size (Mb)', 'Avail (Mb)', 'Partition Disk Size (Mb)', 'Use %',)]
-        for line in stdout.split("\n")[2:]:
+        for line in stdout.split("\n"):
+            if "|" not in line or "pg_database_size" in line:  # Different versions of postgresql
+                continue
             line = filter(None, line.strip().replace('|', '').split(" "))
             if len(line) != 2:
                 continue

--- a/src/smdba/smdba
+++ b/src/smdba/smdba
@@ -39,7 +39,7 @@ class Console:
     """
 
     # General
-    VERSION = "1.6.2"
+    VERSION = "1.6.4"
     DEFAULT_CONFIG = "/etc/rhn/rhn.conf"
 
     # Config


### PR DESCRIPTION
…mismatch

Depending on the postgresql version used, 'smdba space-overview' will hide the first two databases because output has changed.

Also fix the following version mismatch:

e53:~ # rpm -q smdba
smdba-1.6.3-0.1.20.x86_64
e53:~ # smdba
SUSE Manager Database Control. Version 1.6.2

The version number lives in two places that need to match.