### PR TITLE
Change the value of 'work_mem' to more reasonable one

### DIFF
--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -150,7 +150,9 @@ class PgTune:
 
         self.config['shared_buffers'] = self.to_mb(self.bin_rnd(mem / 4))
         self.config['effective_cache_size'] = self.to_mb(self.bin_rnd(mem * 3 / 4))
-        self.config['work_mem'] = self.to_mb(self.bin_rnd(mem / self.max_connections))
+
+        #(total physical RAM - shared_buffers) / (3 * max_connections)
+        self.config['work_mem'] = self.to_mb(self.bin_rnd((mem - self.bin_rnd(mem / 4)) / (3 * self.max_connections)))
 
         # No more than 1GB
         self.config['maintenance_work_mem'] = self.to_mb(self.bin_rnd(mbt if (mem / 0x10) > mbt else mem / 0x10))

--- a/tests/test_pgtune.py
+++ b/tests/test_pgtune.py
@@ -15,7 +15,7 @@ class TestPgTune:
 
     def test_estimate(self):
         """
-        Test estimation.
+         Test estimation with 10 connection and 8GB RAM
 
         :return:
         """
@@ -30,13 +30,39 @@ class TestPgTune:
 
         assert pgtune.config['shared_buffers'] == '1920MB'
         assert pgtune.config['effective_cache_size'] == '5632MB'
-        assert pgtune.config['work_mem'] == '768MB'
+        assert pgtune.config['work_mem'] == '192MB'
         assert pgtune.config['maintenance_work_mem'] == '480MB'
         assert pgtune.config['max_wal_size'] == '384MB'
         assert pgtune.config['checkpoint_completion_target'] == '0.7'
         assert pgtune.config['wal_buffers'] == '4MB'
         assert pgtune.config['constraint_exclusion'] == 'off'
         assert pgtune.config['max_connections'] == 10
+        assert pgtune.config['cpu_tuple_cost'] == '0.5'
+
+    def test_estimate_high_values(self):
+        """
+        Test estimation with 400 connection and 32GB RAM
+
+        :return:
+        """
+
+        popen = MagicMock()
+        popen().read = MagicMock(return_value="11.2")
+
+        with patch("smdba.postgresqlgate.os.popen", popen):
+            pgtune = smdba.postgresqlgate.PgTune(400)
+            pgtune.get_total_memory = MagicMock(return_value=0x773594000)
+            pgtune.estimate()
+
+        assert pgtune.config['shared_buffers'] == '7168MB'
+        assert pgtune.config['effective_cache_size'] == '22528MB'
+        assert pgtune.config['work_mem'] == '18MB'
+        assert pgtune.config['maintenance_work_mem'] == '1024MB'
+        assert pgtune.config['max_wal_size'] == '384MB'
+        assert pgtune.config['checkpoint_completion_target'] == '0.7'
+        assert pgtune.config['wal_buffers'] == '4MB'
+        assert pgtune.config['constraint_exclusion'] == 'off'
+        assert pgtune.config['max_connections'] == 400
         assert pgtune.config['cpu_tuple_cost'] == '0.5'
 
     def test_estimate_low_memory(self):


### PR DESCRIPTION
change the value of 'work_mem' to a more reasonable one. This formula is the same as being used by [Pgtune](https://github.com/le0pard/pgtune/) tool.

## Fixes
https://github.com/SUSE/spacewalk/issues/9015

## Before 

- with 400 connection & 32G ram

`shared_buffers: 7168MB`
 `effective_cache_size: 22528MB`
 `work_mem`: **72MB**
 `maintenance_work_mem: 1024MB`
`max_wal_size: 384MB`
 `checkpoint_completion_target: 0.7`
 `wal_buffers: 4MB`
`constraint_exclusion: off`
 `max_connections: 400`
 `cpu_tuple_cost: 0.5`

## After

- with 400 connection & 32G ram

`shared_buffers: 7168MB`
 `effective_cache_size: 22528MB`
 `work_mem:` **18MB**
 `maintenance_work_mem: 1024MB`
`max_wal_size: 384MB`
 `checkpoint_completion_target: 0.7`
 `wal_buffers: 4MB`
`constraint_exclusion: off`
 `max_connections: 400`
 `cpu_tuple_cost: 0.5`
