### PR TITLE
Postgresql12 restore

### DIFF
--- a/src/smdba/smdba
+++ b/src/smdba/smdba
@@ -23,7 +23,7 @@ class Console:
     """
 
     # General
-    VERSION = "1.7.3"
+    VERSION = "1.7.4"
     DEFAULT_CONFIG = "/etc/rhn/rhn.conf"
 
     # Config


### PR DESCRIPTION
Restore with postgresql 12 works different than before.

The `restore_command` must now go into postgresql.conf and the signal to start the restore process is a file called `recover.signal` which needs to be touched.

Having a file recovery.conf produce an error.

See also https://pgstef.github.io/2018/11/26/postgresql12_preview_recovery_conf_disappears.html

Partly fix: https://github.com/SUSE/spacewalk/issues/10921
