### PR TITLE
Remove custom tuning parameter `cpu_tuple_cost`

### DIFF
--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -167,7 +167,6 @@ class PgTune:
         self.config['wal_buffers'] = self.to_mb(0x200 * 8)
         self.config['constraint_exclusion'] = 'off'
         self.config['max_connections'] = self.max_connections
-        self.config['cpu_tuple_cost'] = '0.5'
 
         return self
 

--- a/tests/test_pgtune.py
+++ b/tests/test_pgtune.py
@@ -37,7 +37,6 @@ class TestPgTune:
         assert pgtune.config['wal_buffers'] == '4MB'
         assert pgtune.config['constraint_exclusion'] == 'off'
         assert pgtune.config['max_connections'] == 10
-        assert pgtune.config['cpu_tuple_cost'] == '0.5'
 
     def test_estimate_high_values(self):
         """
@@ -63,7 +62,6 @@ class TestPgTune:
         assert pgtune.config['wal_buffers'] == '4MB'
         assert pgtune.config['constraint_exclusion'] == 'off'
         assert pgtune.config['max_connections'] == 400
-        assert pgtune.config['cpu_tuple_cost'] == '0.5'
 
     def test_estimate_low_memory(self):
         """


### PR DESCRIPTION
The change introduced in pull #26 had a chance of backfiring and was actually demonstrated to backfire during the optimization of an unrelated area of the codebase (https://github.com/uyuni-project/uyuni/pull/2042), at least in some configuration (a relatively large `work_mem`).

Meanwhile Postgres defaults were tweaked in more recent versions and, crucially, the view this setting was introduced for (allServerKeywordSinceReboot) has meanwhile been dropped (https://github.com/uyuni-project/uyuni/pull/1029).
    
Thus, there is no strong reason to keep this tweak and I am removing it here.
    
Full discussion over the slowdown caused by this parameter, its inadequacy to resolve the particular problem and recommendations from Postgtres's creators not to continue using it is available at:

https://www.postgresql.org/message-id/flat/79dd683d-3296-1b21-ab4a-28fdc2d98807%40suse.de