### PR TITLE
Fix TablePrint formatting

### DIFF
--- a/src/smdba/oraclegate.py
+++ b/src/smdba/oraclegate.py
@@ -465,7 +465,7 @@ class OracleGate(BaseGate):
         for name, free, used, size in [" ".join(filter(None, line.replace("\t", " ").split(" "))).split(" ")
                                        for line in stdout.strip().split("\n")[2:]]:
             table.append((name, free, used, size, str(int(float(used) / float(size) * 100)),))
-        print("\n", TablePrint(table), "\n")
+        print('\n{0}\n'.format(TablePrint(table)))
 
     def do_stats_overview(self, *args, **params):  # pylint: disable=W0613
         """
@@ -868,7 +868,7 @@ class OracleGate(BaseGate):
         table.append(('Total', ('%.2fM' % round(total / 1024. / 1024.))))
 
         if table:
-            print("\n", TablePrint(table), "\n")
+            print('\n{0}\n'.format(TablePrint(table)))
 
         if stderr:
             eprint("Error dump:")

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -437,7 +437,7 @@ class PgSQLGate(BaseGate):
                 table.append((name, t_ref[name],))
             table.append(('', '',))
             table.append(('Total', ('%.2f' % round(t_total / 1024. / 1024)) + 'M',))
-            print("\n", TablePrint(table), "\n")
+            print('\n{0}'.format(TablePrint(table)))
 
     @staticmethod
     def _get_partition(fdir: str) -> str:
@@ -507,7 +507,7 @@ class PgSQLGate(BaseGate):
                              self._bt_to_mb(info.size),
                              '%.3f' % round((float(d_size) / float(info.size) * 100), 3)))
 
-        print("\n", TablePrint(overview), "\n")
+        print('\n{0}\n'.format(TablePrint(overview)))
 
     def do_space_reclaim(self, **args: str) -> None:  # pylint: disable=W0613
         """


### PR DESCRIPTION
Remove leading space from the header to prevent header offsetting to the right side.

Before change:
```
 Database    | DB Size (Mb) | Avail (Mb) | Partition Disk Size (Mb) | Use %
------------+--------------+------------+--------------------------+------
postgres    | 8            | 198080     | 204761                   | 0.004
susemanager | 63           | 198080     | 204761                   | 0.031
template1   | 8            | 198080     | 204761                   | 0.004
template0   | 8            | 198080     | 204761                   | 0.004
```
After change:
```
Database    | DB Size (Mb) | Avail (Mb) | Partition Disk Size (Mb) | Use %
------------+--------------+------------+--------------------------+------
postgres    | 8            | 198080     | 204761                   | 0.004
susemanager | 63           | 198080     | 204761                   | 0.031
template1   | 8            | 198080     | 204761                   | 0.004
template0   | 8            | 198080     | 204761                   | 0.004
```