### PR TITLE
remove wal_keep_segments from postgresql.conf in new pg versions

### DIFF
--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -1003,6 +1003,9 @@ class PgSQLGate(BaseGate):
             if conf.get('wal_keep_size', '0') == '0':
                 conf['wal_keep_size'] = 1024
                 changed = True
+            if conf.get('wal_keep_segments', '0') != '0':
+                del conf['wal_keep_segments']
+                changed = True
 
         # Should run in archive mode
         if conf.get('archive_mode', 'off') != 'on':


### PR DESCRIPTION
In postgresql starting with version 13 the option wal_keep_segments was replaced by wall_keep_size.
While smdba set the option, it does not remove the obsoleted option which cause postgresql not been able to start.

This PR fix this problem.

Fixes https://github.com/SUSE/spacewalk/issues/19305