### PR TITLE
keep ssd option when no option is set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
   name='SUSE Manager Database Control',
-  version='1.7.11',
+  version='1.7.12',
   package_dir= {'': 'src'},
   package_data={'smdba': ['scenarios/*.scn']},
   packages=['smdba'],

--- a/src/smdba/postgresqlgate.py
+++ b/src/smdba/postgresqlgate.py
@@ -975,7 +975,9 @@ class PgSQLGate(BaseGate):
             print('INFO: max_connections should be at least {0}'.format(conn_lowest))
             max_conn = conn_lowest
 
-        ssd = params.get('ssd', False)
+        # ssd set default to 200 - default is HDD / false
+        ssd_default = int(conf.get('effective_io_concurrency', 2)) > 100
+        ssd = params.get('ssd', ssd_default)
         if 'autotuning' in args:
             for item, value in PgTune(max_conn, ssd).estimate().config.items():
                 if not changed and str(conf.get(item, None)) != str(value):

--- a/src/smdba/smdba
+++ b/src/smdba/smdba
@@ -23,7 +23,7 @@ class Console:
     """
 
     # General
-    VERSION = "1.7.11"
+    VERSION = "1.7.12"
     DEFAULT_CONFIG = "/etc/rhn/rhn.conf"
 
     # Config


### PR DESCRIPTION
When ssd was configured before and autotuning is run again without option, keep ssd configuration